### PR TITLE
Fixed compatibility issue with grunt-mocha-istanbul

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,17 +18,17 @@
   "author": "Elliot Foster",
   "license": "MIT",
   "devDependencies": {
-    "chai": "^1.0.0",
-    "mocha": "^1.0.0",
-    "sinon": "^1.0.0",
+    "chai": "~1",
+    "mocha": "~1",
+    "sinon": "~1",
     "mocha-phantomjs": "^3.3.2",
     "phantomjs": "^1.9.7-3",
     "chicken-little": "^0.1.2",
     "sinon-chai": "^2.5.0"
   },
   "peerDependencies": {
-    "mocha": "^1.0.0",
-    "sinon": "^1.0.0"
+    "mocha": "~1",
+    "sinon": "~1"
   },
   "engines": {
     "npm": ">1.2"


### PR DESCRIPTION
Version 1.1.1 added one simple bug

At travis build under node 0.8:

```
npm ERR! peerinvalid The package mocha does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer grunt-mocha-istanbul@1.2.0 wants mocha@*
npm ERR! peerinvalid Peer mocha-sinon@1.1.1 wants mocha@^1.0.0
```

Reverting some version dep changes in package.json fixes issue
