### PR TITLE
add support for `this.sinon` in `after` and  `before` hooks

### DIFF
--- a/mocha-sinon.js
+++ b/mocha-sinon.js
@@ -11,7 +11,19 @@ function mochaSinon(sinon){
     }
   });
 
+  before(function() {
+    if (null == this.sinon) {
+      this.sinon = sinon.sandbox.create();
+    }
+  });
+
   afterEach(function() {
+    if (this.sinon && 'function' === typeof this.sinon.restore) {
+      this.sinon.restore();
+    }
+  });
+
+  after(function() {
     if (this.sinon && 'function' === typeof this.sinon.restore) {
       this.sinon.restore();
     }

--- a/test/mocha-sinon-base-spec.js
+++ b/test/mocha-sinon-base-spec.js
@@ -63,6 +63,8 @@
         it("exports a function to register beforeEach/afterEach", function() {
           sandbox.spy(global, 'beforeEach');
           sandbox.spy(global, 'afterEach');
+          sandbox.spy(global, 'before');
+          sandbox.spy(global, 'after');
 
           expect(subject).to.be.a('function');
 
@@ -70,6 +72,8 @@
 
           expect(global.beforeEach).to.have.been.called;
           expect(global.afterEach).to.have.been.called;
+          expect(global.before).to.have.been.called;
+          expect(global.after).to.have.been.called;
         });
       });
     })();


### PR DESCRIPTION
not sure if this creates complex cases in suites that use combinations of all of the before/after/beforeEach/afterEach, but for my simple case it seems to work OK. I guess with both `before` and `beforeEach` you'd create an unnecessary sandbox in `before` that just gets replaced by the ones created in `beforeEach`, but I don't think that's a big deal. This does let you use just `before` and `after` though, which was my motivation for this PR.
