### PR TITLE
[Typings] Augment Context instead of Suite

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ import { SinonSandbox } from 'sinon'
 
 declare global {
 	namespace Mocha {
-		interface Suite {
+		interface Context {
 			sinon: SinonSandbox;
 		}
 	}


### PR DESCRIPTION
Turns out I was right in #20 (hate it when that happens...), I was augmenting the wrong interface.

I didn't notice before because the `Context` interface [has an `any`-indexing type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7caeca4bfbd5ca9f306c14def3dd6b416869c615/types/mocha/index.d.ts#L1354). This is a prime example of why I don't like having those...

Sorry for the trouble!